### PR TITLE
Fix toast imports

### DIFF
--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -10,10 +10,11 @@ import {
   isIncognito,
   AnalyticsData,
 } from '../services/analytics';
-import { toast } from 'react-toastify';
+import { useToast } from '../components/ToastProvider';
 
 export function useAnalytics() {
   const [data, setData] = useState<AnalyticsData>(() => getAnalytics());
+  const { showSuccess } = useToast();
 
   const refresh = useCallback(() => {
     setData(getAnalytics());
@@ -27,7 +28,7 @@ export function useAnalytics() {
   const click = useCallback(
     (id: string) => {
       recordLinkClick(id);
-      toast.info('Клик по ссылке');
+      showSuccess('Клик по ссылке');
       refresh();
     },
     [refresh],
@@ -36,7 +37,7 @@ export function useAnalytics() {
   const react = useCallback(
     (emoji: string) => {
       recordReaction(emoji);
-      toast.success('Реакция сохранена');
+      showSuccess('Реакция сохранена');
       refresh();
     },
     [refresh],
@@ -45,7 +46,7 @@ export function useAnalytics() {
   const comment = useCallback(
     (text: string) => {
       addComment(text);
-      toast.success('Комментарий добавлен');
+      showSuccess('Комментарий добавлен');
       refresh();
     },
     [refresh],

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useToast } from '../components/Toast';
+import { useToast } from '../components/ToastProvider';
 
 export interface AsyncState<T> {
   loading: boolean;
@@ -9,7 +9,7 @@ export interface AsyncState<T> {
 
 export function useAsync<T>(asyncFn: () => Promise<T>) {
   const [state, setState] = useState<AsyncState<T>>({ loading: false });
-  const { showToast } = useToast();
+  const { showError } = useToast();
 
   const run = useCallback(async () => {
     setState({ loading: true });
@@ -18,7 +18,7 @@ export function useAsync<T>(asyncFn: () => Promise<T>) {
       setState({ loading: false, data });
     } catch (error) {
       setState({ loading: false, error });
-      showToast('Ошибка');
+      showError('Ошибка');
     }
   }, [asyncFn]);
 


### PR DESCRIPTION
## Summary
- update toast hook import path in useAsync
- use ToastProvider in useAnalytics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684481493980832ea4c89200f81ad12d