### PR TITLE
Fix ESLint warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-react": "^7.33.2",
         "jsdom": "^26.1.0",
         "prettier": "^3.2.5",
-        "typescript": "~5.7.2",
+        "typescript": "~5.5.4",
         "vite": "^6.2.0",
         "vitest": "^3.2.2"
       }
@@ -6944,9 +6944,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-react": "^7.33.2",
     "jsdom": "^26.1.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.7.2",
+    "typescript": "~5.5.4",
     "vite": "^6.2.0",
     "vitest": "^3.2.2"
   }


### PR DESCRIPTION
## Summary
- downgrade TypeScript to 5.5 for compatibility with eslint

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684483ae6544832eae4aeb01289d66d0