### PR TITLE
Enhance profile editor page

### DIFF
--- a/components/ProfileEditor.tsx
+++ b/components/ProfileEditor.tsx
@@ -8,11 +8,19 @@ import { Toast } from './Toast';
 
 interface Props {
   userId: string;
+  onUnsavedChanges?: (changed: boolean) => void;
+  onSaveSuccess?: () => void;
+  onError?: (err: unknown) => void;
 }
 
 const defaultProfile: UserProfile = { name: '', email: '', bio: '' };
 
-export const ProfileEditor: React.FC<Props> = ({ userId }) => {
+export const ProfileEditor: React.FC<Props> = ({
+  userId,
+  onUnsavedChanges,
+  onSaveSuccess,
+  onError,
+}) => {
   const [toast, setToast] = useState<string | null>(null);
   const { state, set, undo, redo, canUndo, canRedo } =
     useUndoRedo<UserProfile>(defaultProfile);
@@ -21,6 +29,10 @@ export const ProfileEditor: React.FC<Props> = ({ userId }) => {
     'profile',
     state
   );
+
+  useEffect(() => {
+    onUnsavedChanges?.(!saved);
+  }, [saved, onUnsavedChanges]);
 
   useEffect(() => {
     const draft = loadDraft();
@@ -78,8 +90,10 @@ export const ProfileEditor: React.FC<Props> = ({ userId }) => {
       void saveData('profiles', userId, state);
       clearDraft();
       setToast('Профиль опубликован');
-    } catch {
+      onSaveSuccess?.();
+    } catch (err) {
       setToast('Ошибка при сохранении');
+      onError?.(err);
     }
   };
 

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import { useAuth as useAuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  const ctx = useAuthContext();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshUser = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // В реальном приложении здесь можно запрашивать данные пользователя
+      // с сервера. Текущее состояние берётся из контекста.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    ...ctx,
+    loading,
+    error,
+    isAuthenticated: Boolean(ctx.user),
+    refreshUser,
+  };
+}
+
+export default useAuth;

--- a/pages/ProfileEditorPage.tsx
+++ b/pages/ProfileEditorPage.tsx
@@ -1,13 +1,140 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { ProfileEditor } from '../components/ProfileEditor';
+import useAuth from '../hooks/useAuth';
+
+const LoadingSpinner: React.FC = () => (
+  <div className="flex justify-center items-center min-h-[400px]">
+    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+    <span className="ml-3 text-gray-600">Загрузка...</span>
+  </div>
+);
+
+const ErrorMessage: React.FC<{ message: string; onRetry?: () => void }> = ({
+  message,
+  onRetry,
+}) => (
+  <div className="flex flex-col items-center justify-center min-h-[400px] bg-red-50 rounded-lg p-8">
+    <div className="text-red-600 text-xl mb-4">⚠️ Ошибка</div>
+    <p className="text-gray-700 text-center mb-4">{message}</p>
+    {onRetry && (
+      <button
+        onClick={onRetry}
+        className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors"
+      >
+        Попробовать снова
+      </button>
+    )}
+  </div>
+);
 
 const ProfileEditorPage: React.FC = () => {
-  // In real app user id should come from auth context
-  const userId = 'user1';
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, loading, error, isAuthenticated, refreshUser } = useAuth();
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      navigate('/login', {
+        state: { from: location.pathname },
+        replace: true,
+      });
+    }
+  }, [loading, isAuthenticated, navigate, location]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+        e.returnValue =
+          'У вас есть несохраненные изменения. Вы уверены, что хотите покинуть страницу?';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  const handleRetry = () => {
+    refreshUser?.();
+  };
+
+  if (loading) {
+    return (
+      <StandardPageLayout
+        title="Редактирование профиля"
+        description="Настройте свой профиль и персональную информацию"
+      >
+        <LoadingSpinner />
+      </StandardPageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <StandardPageLayout
+        title="Ошибка загрузки профиля"
+        description="Произошла ошибка при загрузке данных профиля"
+      >
+        <ErrorMessage
+          message="Не удалось загрузить данные профиля. Проверьте подключение к интернету и попробуйте снова."
+          onRetry={handleRetry}
+        />
+      </StandardPageLayout>
+    );
+  }
+
+  if (!user || !isAuthenticated) {
+    return (
+      <StandardPageLayout
+        title="Доступ запрещен"
+        description="Необходима авторизация для доступа к этой странице"
+      >
+        <ErrorMessage message="Для редактирования профиля необходимо войти в систему." />
+      </StandardPageLayout>
+    );
+  }
+
   return (
-    <StandardPageLayout title="Редактирование профиля">
-      <ProfileEditor userId={userId} />
+    <StandardPageLayout
+      title="Редактирование профиля"
+      description="Настройте свой профиль и персональную информацию"
+      breadcrumbs={[
+        { label: 'Главная', href: '/' },
+        { label: 'Профиль', href: '/profile' },
+        { label: 'Редактирование', href: '/profile/edit' },
+      ]}
+    >
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Редактирование профиля</h1>
+          <p className="text-gray-600">Обновите свои личные данные и настройки аккаунта</p>
+        </div>
+
+        {hasUnsavedChanges && (
+          <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <span className="text-yellow-400">⚠️</span>
+              </div>
+              <div className="ml-3">
+                <p className="text-sm text-yellow-700">
+                  У вас есть несохраненные изменения. Не забудьте сохранить данные перед выходом.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <ProfileEditor
+          userId={user.id}
+          onUnsavedChanges={setHasUnsavedChanges}
+          onSaveSuccess={() => setHasUnsavedChanges(false)}
+          onError={err => console.error('Profile editor error:', err)}
+        />
+      </div>
     </StandardPageLayout>
   );
 };


### PR DESCRIPTION
## Summary
- implement hook `useAuth` to expose auth status
- update `ProfileEditor` with callbacks
- redesign `ProfileEditorPage` with loading and error states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844876270d4832eadf79c73d38aac1f