### PR TITLE
Enhance account settings with notifications

### DIFF
--- a/components/ProfileEditor.tsx
+++ b/components/ProfileEditor.tsx
@@ -8,11 +8,19 @@ import { Toast } from './Toast';
 
 interface Props {
   userId: string;
+  onUnsavedChanges?: (changed: boolean) => void;
+  onSaveSuccess?: () => void;
+  onError?: (err: unknown) => void;
 }
 
 const defaultProfile: UserProfile = { name: '', email: '', bio: '' };
 
-export const ProfileEditor: React.FC<Props> = ({ userId }) => {
+export const ProfileEditor: React.FC<Props> = ({
+  userId,
+  onUnsavedChanges,
+  onSaveSuccess,
+  onError,
+}) => {
   const [toast, setToast] = useState<string | null>(null);
   const { state, set, undo, redo, canUndo, canRedo } =
     useUndoRedo<UserProfile>(defaultProfile);
@@ -21,6 +29,10 @@ export const ProfileEditor: React.FC<Props> = ({ userId }) => {
     'profile',
     state
   );
+
+  useEffect(() => {
+    onUnsavedChanges?.(!saved);
+  }, [saved, onUnsavedChanges]);
 
   useEffect(() => {
     const draft = loadDraft();
@@ -78,8 +90,10 @@ export const ProfileEditor: React.FC<Props> = ({ userId }) => {
       void saveData('profiles', userId, state);
       clearDraft();
       setToast('Профиль опубликован');
-    } catch {
+      onSaveSuccess?.();
+    } catch (err) {
       setToast('Ошибка при сохранении');
+      onError?.(err);
     }
   };
 

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import { useAuth as useAuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  const ctx = useAuthContext();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshUser = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // В реальном приложении здесь можно запрашивать данные пользователя
+      // с сервера. Текущее состояние берётся из контекста.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    ...ctx,
+    loading,
+    error,
+    isAuthenticated: Boolean(ctx.user),
+    refreshUser,
+  };
+}
+
+export default useAuth;

--- a/hooks/useNotification.ts
+++ b/hooks/useNotification.ts
@@ -1,0 +1,17 @@
+import { useToast } from '../components/ToastProvider';
+
+export function useNotification() {
+  const { showSuccess, showError } = useToast();
+
+  const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
+    if (type === 'success') {
+      showSuccess(message);
+    } else {
+      showError(message);
+    }
+  };
+
+  return { showNotification };
+}
+
+export default useNotification;

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './components/ToastProvider';
 import './index.css';
 
 const savedTheme = localStorage.getItem('theme');
@@ -25,7 +26,9 @@ root.render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/pages/AccountSettingsPage.tsx
+++ b/pages/AccountSettingsPage.tsx
@@ -1,193 +1,566 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import StandardPageLayout from '../layouts/StandardPageLayout';
-import { Link } from 'react-router-dom';
+import useAuth from '../hooks/useAuth';
+import useNotification from '../hooks/useNotification';
 
-const SectionCard: React.FC<{ title: string; children: React.ReactNode }> = ({
-  title,
-  children,
-}) => (
-  <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6">
-    <h3 className="text-xl font-semibold font-pragmatica text-gray-800 mb-4">
-      {title}
-    </h3>
-    {children}
+interface UserData {
+  id: string;
+  name: string;
+  email: string;
+  avatar?: string;
+  socialProfile?: string;
+  twoFactorEnabled: boolean;
+  subscription: {
+    plan: string;
+    status: string;
+  };
+}
+
+interface ActivityLog {
+  id: string;
+  action: string;
+  timestamp: string;
+  ip?: string;
+}
+
+interface ApiKey {
+  id: string;
+  name: string;
+  key: string;
+  created: string;
+  lastUsed?: string;
+}
+
+const LoadingSpinner: React.FC = () => (
+  <div className="flex justify-center items-center py-8">
+    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+    <span className="ml-3 text-gray-600">Загрузка...</span>
   </div>
 );
 
-const FormField: React.FC<{
-  label: string;
-  type: string;
-  id: string;
-  value?: string;
-  placeholder?: string;
-}> = ({ label, type, id, value, placeholder }) => (
-  <div>
-    <label htmlFor={id} className="block text-sm font-medium text-gray-700">
-      {label}
-    </label>
-    <input
-      type={type}
-      id={id}
-      name={id}
-      defaultValue={value}
-      placeholder={placeholder}
-      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-    />
+const ErrorMessage: React.FC<{ message: string; onRetry?: () => void }> = ({
+  message,
+  onRetry,
+}) => (
+  <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+    <div className="flex items-center">
+      <span className="text-red-500 text-xl mr-3">⚠️</span>
+      <div>
+        <p className="text-red-700">{message}</p>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 text-sm text-red-600 hover:text-red-800 underline"
+          >
+            Попробовать снова
+          </button>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+const SuccessMessage: React.FC<{ message: string }> = ({ message }) => (
+  <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+    <div className="flex items-center">
+      <span className="text-green-500 text-xl mr-3">✅</span>
+      <p className="text-green-700">{message}</p>
+    </div>
+  </div>
+);
+
+const SectionCard: React.FC<{
+  title: string;
+  children: React.ReactNode;
+  loading?: boolean;
+  error?: string;
+  onRetry?: () => void;
+}> = ({ title, children, loading, error, onRetry }) => (
+  <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6">
+    <h3 className="text-xl font-semibold text-gray-800 mb-4">{title}</h3>
+    {loading ? <LoadingSpinner /> : error ? <ErrorMessage message={error} onRetry={onRetry} /> : children}
   </div>
 );
 
 const AccountSettingsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { user, isAuthenticated, loading: authLoading, updateUser } = useAuth();
+  const { showNotification } = useNotification();
+
+  const [userData, setUserData] = useState<UserData | null>(null);
+  const [activityLogs, setActivityLogs] = useState<ActivityLog[]>([]);
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [success, setSuccess] = useState<Record<string, string>>({});
+
+  const [profileForm, setProfileForm] = useState({
+    name: '',
+    email: '',
+    socialProfile: '',
+  });
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      navigate('/login', { replace: true });
+      return;
+    }
+  }, [authLoading, isAuthenticated, navigate]);
+
+  useEffect(() => {
+    if (user) {
+      loadUserData();
+    }
+  }, [user]);
+
+  const loadUserData = async () => {
+    try {
+      setLoading(true);
+      const [userResponse, activityResponse, apiKeysResponse] = await Promise.all([
+        fetch('/api/user/profile'),
+        fetch('/api/user/activity'),
+        fetch('/api/user/api-keys'),
+      ]);
+
+      if (!userResponse.ok) throw new Error('Ошибка загрузки профиля');
+      if (!activityResponse.ok) throw new Error('Ошибка загрузки активности');
+      if (!apiKeysResponse.ok) throw new Error('Ошибка загрузки API ключей');
+
+      const userData = await userResponse.json();
+      const activityData = await activityResponse.json();
+      const apiKeysData = await apiKeysResponse.json();
+
+      setUserData(userData);
+      setActivityLogs(activityData.logs || []);
+      setApiKeys(apiKeysData.keys || []);
+
+      setProfileForm({
+        name: userData.name || '',
+        email: userData.email || '',
+        socialProfile: userData.socialProfile || '',
+      });
+    } catch (error) {
+      console.error('Error loading user data:', error);
+      setErrors({ general: 'Ошибка загрузки данных. Попробуйте обновить страницу.' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveProfile = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving({ ...saving, profile: true });
+    setErrors({ ...errors, profile: '' });
+    setSuccess({ ...success, profile: '' });
+
+    try {
+      if (!profileForm.name.trim()) {
+        throw new Error('Имя не может быть пустым');
+      }
+      if (!profileForm.email.includes('@')) {
+        throw new Error('Некорректный email адрес');
+      }
+
+      const response = await fetch('/api/user/profile', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(profileForm),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Ошибка сохранения');
+      }
+
+      const updatedUser = await response.json();
+      setUserData(updatedUser);
+      await updateUser?.(updatedUser);
+
+      setSuccess({ ...success, profile: 'Профиль успешно обновлен!' });
+      showNotification('Профиль обновлен', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Ошибка сохранения';
+      setErrors({ ...errors, profile: message });
+      showNotification(message, 'error');
+    } finally {
+      setSaving({ ...saving, profile: false });
+    }
+  };
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving({ ...saving, password: true });
+    setErrors({ ...errors, password: '' });
+    setSuccess({ ...success, password: '' });
+
+    try {
+      if (passwordForm.newPassword.length < 8) {
+        throw new Error('Пароль должен содержать минимум 8 символов');
+      }
+      if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+        throw new Error('Пароли не совпадают');
+      }
+
+      const response = await fetch('/api/user/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          currentPassword: passwordForm.currentPassword,
+          newPassword: passwordForm.newPassword,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Ошибка смены пароля');
+      }
+
+      setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      setSuccess({ ...success, password: 'Пароль успешно изменен!' });
+      showNotification('Пароль изменен', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Ошибка смены пароля';
+      setErrors({ ...errors, password: message });
+      showNotification(message, 'error');
+    } finally {
+      setSaving({ ...saving, password: false });
+    }
+  };
+
+  const handleAvatarUpload = async (file: File) => {
+    setSaving({ ...saving, avatar: true });
+    try {
+      const formData = new FormData();
+      formData.append('avatar', file);
+
+      const response = await fetch('/api/user/avatar', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) throw new Error('Ошибка загрузки аватара');
+
+      const result = await response.json();
+      setUserData((prev) => (prev ? { ...prev, avatar: result.avatarUrl } : null));
+      showNotification('Аватар обновлен', 'success');
+    } catch (error) {
+      showNotification('Ошибка загрузки аватара', 'error');
+    } finally {
+      setSaving({ ...saving, avatar: false });
+    }
+  };
+
+  const toggle2FA = async () => {
+    setSaving({ ...saving, twoFactor: true });
+    try {
+      const response = await fetch('/api/user/2fa/toggle', {
+        method: 'POST',
+      });
+
+      if (!response.ok) throw new Error('Ошибка настройки 2FA');
+
+      const result = await response.json();
+      setUserData((prev) => (prev ? { ...prev, twoFactorEnabled: result.enabled } : null));
+      showNotification(result.enabled ? '2FA включена' : '2FA отключена', 'success');
+    } catch (error) {
+      showNotification('Ошибка настройки 2FA', 'error');
+    } finally {
+      setSaving({ ...saving, twoFactor: false });
+    }
+  };
+
+  const generateApiKey = async () => {
+    setSaving({ ...saving, apiKey: true });
+    try {
+      const response = await fetch('/api/user/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: `Key ${Date.now()}` }),
+      });
+
+      if (!response.ok) throw new Error('Ошибка генерации API ключа');
+
+      const newKey = await response.json();
+      setApiKeys((prev) => [...prev, newKey]);
+      showNotification('API ключ создан', 'success');
+    } catch (error) {
+      showNotification('Ошибка создания API ключа', 'error');
+    } finally {
+      setSaving({ ...saving, apiKey: false });
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <StandardPageLayout title="Настройки аккаунта">
+        <LoadingSpinner />
+      </StandardPageLayout>
+    );
+  }
+
+  if (!isAuthenticated || !userData) {
+    return (
+      <StandardPageLayout title="Доступ запрещен">
+        <ErrorMessage message="Необходимо войти в систему для доступа к настройкам аккаунта" />
+      </StandardPageLayout>
+    );
+  }
+
   return (
-    <StandardPageLayout title="6. Account Settings">
-      <div className="space-y-8">
-        <SectionCard title="Основная информация">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="space-y-4">
-              <FormField
-                label="Имя"
-                type="text"
-                id="name"
-                value="Текущее Имя"
-              />
-              <FormField
-                label="Email"
-                type="email"
-                id="email"
-                value="user@example.com"
-              />
-              <button
-                type="button"
-                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
-              >
-                Сохранить изменения
-              </button>
-            </div>
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">
-                Аватар
-              </label>
-              <div className="flex items-center space-x-4">
-                <div className="w-24 h-24 bg-gray-300 rounded-full flex items-center justify-center text-gray-500">
-                  Фото
+    <StandardPageLayout
+      title="Настройки аккаунта"
+      description="Управление профилем, безопасностью и настройками аккаунта"
+      breadcrumbs={[
+        { label: 'Главная', href: '/' },
+        { label: 'Настройки аккаунта', href: '/account/settings' },
+      ]}
+    >
+      <div className="max-w-4xl mx-auto space-y-8">
+        <SectionCard title="Основная информация" loading={saving.profile} error={errors.profile}>
+          {success.profile && <SuccessMessage message={success.profile} />}
+          <form onSubmit={handleSaveProfile}>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                    Имя *
+                  </label>
+                  <input
+                    type="text"
+                    id="name"
+                    value={profileForm.name}
+                    onChange={(e) => setProfileForm({ ...profileForm, name: e.target.value })}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                    Email *
+                  </label>
+                  <input
+                    type="email"
+                    id="email"
+                    value={profileForm.email}
+                    onChange={(e) => setProfileForm({ ...profileForm, email: e.target.value })}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="socialProfile" className="block text-sm font-medium text-gray-700">
+                    Профиль в соцсети
+                  </label>
+                  <input
+                    type="url"
+                    id="socialProfile"
+                    value={profileForm.socialProfile}
+                    onChange={(e) => setProfileForm({ ...profileForm, socialProfile: e.target.value })}
+                    placeholder="https://linkedin.com/in/username"
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  />
                 </div>
                 <button
-                  type="button"
-                  className="text-sm text-indigo-600 hover:underline"
+                  type="submit"
+                  disabled={saving.profile}
+                  className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  Загрузить новый
+                  {saving.profile ? 'Сохранение...' : 'Сохранить изменения'}
                 </button>
               </div>
-              <FormField
-                label="Профиль в соцсети (пример)"
-                type="url"
-                id="social_profile"
-                placeholder="https://linkedin.com/in/username"
-              />
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Аватар</label>
+                  <div className="flex items-center space-x-4">
+                    <div className="w-24 h-24 bg-gray-300 rounded-full flex items-center justify-center text-gray-500 overflow-hidden">
+                      {userData.avatar ? <img src={userData.avatar} alt="Avatar" className="w-full h-full object-cover" /> : 'Фото'}
+                    </div>
+                    <div>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (file) handleAvatarUpload(file);
+                        }}
+                        className="hidden"
+                        id="avatar-upload"
+                      />
+                      <label htmlFor="avatar-upload" className="cursor-pointer text-sm text-indigo-600 hover:underline">
+                        {saving.avatar ? 'Загрузка...' : 'Загрузить новый'}
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
+          </form>
         </SectionCard>
 
-        <SectionCard title="Безопасность">
-          <div className="space-y-4">
+        <SectionCard title="Безопасность" loading={saving.password || saving.twoFactor} error={errors.password}>
+          {success.password && <SuccessMessage message={success.password} />}
+          <div className="space-y-6">
             <div>
-              <h4 className="font-medium text-gray-800">Смена пароля</h4>
-              <FormField
-                label="Текущий пароль"
-                type="password"
-                id="current_password"
-                placeholder="••••••••"
-              />
-              <FormField
-                label="Новый пароль"
-                type="password"
-                id="new_password"
-                placeholder="••••••••"
-              />
-              <FormField
-                label="Подтвердите новый пароль"
-                type="password"
-                id="confirm_password"
-                placeholder="••••••••"
-              />
-              <button
-                type="button"
-                className="mt-2 px-4 py-2 bg-orange-500 text-white text-sm font-medium rounded-md hover:bg-orange-600"
-              >
-                Изменить пароль
-              </button>
+              <h4 className="font-medium text-gray-800 mb-4">Смена пароля</h4>
+              <form onSubmit={handleChangePassword}>
+                <div className="space-y-4 max-w-md">
+                  <div>
+                    <label htmlFor="currentPassword" className="block text-sm font-medium text-gray-700">
+                      Текущий пароль
+                    </label>
+                    <input
+                      type="password"
+                      id="currentPassword"
+                      value={passwordForm.currentPassword}
+                      onChange={(e) => setPasswordForm({ ...passwordForm, currentPassword: e.target.value })}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700">
+                      Новый пароль
+                    </label>
+                    <input
+                      type="password"
+                      id="newPassword"
+                      value={passwordForm.newPassword}
+                      onChange={(e) => setPasswordForm({ ...passwordForm, newPassword: e.target.value })}
+                      minLength={8}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+                      Подтвердите новый пароль
+                    </label>
+                    <input
+                      type="password"
+                      id="confirmPassword"
+                      value={passwordForm.confirmPassword}
+                      onChange={(e) => setPasswordForm({ ...passwordForm, confirmPassword: e.target.value })}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                      required
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={saving.password}
+                    className="px-4 py-2 bg-orange-500 text-white text-sm font-medium rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {saving.password ? 'Изменение...' : 'Изменить пароль'}
+                  </button>
+                </div>
+              </form>
             </div>
             <div>
-              <h4 className="font-medium text-gray-800">
-                Двухфакторная аутентификация (2FA)
-              </h4>
-              <p className="text-sm text-gray-600 mb-2">
+              <h4 className="font-medium text-gray-800 mb-2">Двухфакторная аутентификация (2FA)</h4>
+              <p className="text-sm text-gray-600 mb-4">
                 Статус:{' '}
-                <span className="font-semibold text-green-600">Включена</span>
+                <span className={`font-semibold ${userData.twoFactorEnabled ? 'text-green-600' : 'text-red-600'}`}>{
+                  userData.twoFactorEnabled ? 'Включена' : 'Отключена'
+                }</span>
               </p>
               <button
-                type="button"
-                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50"
+                onClick={toggle2FA}
+                disabled={saving.twoFactor}
+                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                Управлять 2FA
+                {saving.twoFactor ? 'Обновление...' : userData.twoFactorEnabled ? 'Отключить 2FA' : 'Включить 2FA'}
               </button>
             </div>
           </div>
         </SectionCard>
 
         <SectionCard title="Управление подпиской">
-          <p className="text-sm text-gray-600 mb-2">
-            Ваш текущий тариф:{' '}
-            <span className="font-semibold text-green-600">Pro Plan</span>
-          </p>
-          <Link
-            to="/billing"
-            className="px-4 py-2 bg-teal-500 text-white text-sm font-medium rounded-md hover:bg-teal-600"
-          >
-            Перейти к оплате и тарифам
-          </Link>
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+              Ваш текущий тариф:{' '}
+              <span className="font-semibold text-green-600">{userData.subscription.plan}</span>
+            </p>
+            <p className="text-sm text-gray-600">
+              Статус:{' '}
+              <span className={`font-semibold ${userData.subscription.status === 'active' ? 'text-green-600' : 'text-orange-600'}`}>{
+                userData.subscription.status === 'active' ? 'Активен' : 'Неактивен'
+              }</span>
+            </p>
+            <button
+              onClick={() => navigate('/billing')}
+              className="px-4 py-2 bg-teal-500 text-white text-sm font-medium rounded-md hover:bg-teal-600"
+            >
+              Управлять подпиской
+            </button>
+          </div>
         </SectionCard>
 
         <SectionCard title="История активности">
-          <p className="text-sm text-gray-600 mb-2">
-            Последние действия в вашем аккаунте:
-          </p>
-          <ul className="list-disc list-inside text-sm text-gray-500 space-y-1">
-            <li>Вход в систему с IP 192.168.1.1 (Сегодня, 10:15)</li>
-            <li>Страница "Мое Портфолио v1" обновлена (Вчера, 18:30)</li>
-            <li>Изменен email аккаунта (05.07.2024)</li>
-          </ul>
-          <a
-            href="#"
-            className="text-sm text-indigo-600 hover:underline mt-2 inline-block"
-          >
-            Посмотреть всю историю
-          </a>
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600">Последние действия в вашем аккаунте:</p>
+            {activityLogs.length > 0 ? (
+              <div className="space-y-2">
+                {activityLogs.slice(0, 5).map((log) => (
+                  <div key={log.id} className="text-sm text-gray-600 p-2 bg-gray-50 rounded">
+                    <span className="font-medium">{log.action}</span>
+                    <span className="text-gray-500"> - {new Date(log.timestamp).toLocaleString()}</span>
+                    {log.ip && <span className="text-gray-400"> (IP: {log.ip})</span>}
+                  </div>
+                ))}
+                <button onClick={() => navigate('/account/activity')} className="text-sm text-indigo-600 hover:underline">
+                  Посмотреть всю историю
+                </button>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">История активности пуста</p>
+            )}
+          </div>
         </SectionCard>
 
         <SectionCard title="API и Интеграции">
-          <div>
-            <h4 className="font-medium text-gray-800">API-ключи</h4>
-            <p className="text-sm text-gray-600 mb-2">
-              У вас нет активных API-ключей.
-            </p>
-            <button
-              type="button"
-              className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50"
-            >
-              Сгенерировать API-ключ
-            </button>
-          </div>
-          <div className="mt-4">
-            <h4 className="font-medium text-gray-800">Webhooks</h4>
-            <p className="text-sm text-gray-600 mb-2">
-              Настройте webhooks для получения уведомлений о событиях.
-            </p>
-            <button
-              type="button"
-              className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50"
-            >
-              Управлять Webhooks
-            </button>
+          <div className="space-y-6">
+            <div>
+              <h4 className="font-medium text-gray-800 mb-4">API-ключи</h4>
+              {apiKeys.length > 0 ? (
+                <div className="space-y-2 mb-4">
+                  {apiKeys.map((key) => (
+                    <div key={key.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
+                      <div>
+                        <span className="font-medium">{key.name}</span>
+                        <span className="text-sm text-gray-500 ml-2">Создан: {new Date(key.created).toLocaleDateString()}</span>
+                        {key.lastUsed && (
+                          <span className="text-sm text-gray-500 ml-2">Последнее использование: {new Date(key.lastUsed).toLocaleDateString()}</span>
+                        )}
+                      </div>
+                      <button
+                        onClick={() => {
+                          setApiKeys((prev) => prev.filter((k) => k.id !== key.id));
+                        }}
+                        className="text-red-600 text-sm hover:underline"
+                      >
+                        Удалить
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-600 mb-4">У вас нет активных API-ключей.</p>
+              )}
+              <button
+                onClick={generateApiKey}
+                disabled={saving.apiKey}
+                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {saving.apiKey ? 'Генерация...' : 'Сгенерировать API-ключ'}
+              </button>
+            </div>
           </div>
         </SectionCard>
       </div>

--- a/pages/ProfileEditorPage.tsx
+++ b/pages/ProfileEditorPage.tsx
@@ -1,13 +1,140 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { ProfileEditor } from '../components/ProfileEditor';
+import useAuth from '../hooks/useAuth';
+
+const LoadingSpinner: React.FC = () => (
+  <div className="flex justify-center items-center min-h-[400px]">
+    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+    <span className="ml-3 text-gray-600">Загрузка...</span>
+  </div>
+);
+
+const ErrorMessage: React.FC<{ message: string; onRetry?: () => void }> = ({
+  message,
+  onRetry,
+}) => (
+  <div className="flex flex-col items-center justify-center min-h-[400px] bg-red-50 rounded-lg p-8">
+    <div className="text-red-600 text-xl mb-4">⚠️ Ошибка</div>
+    <p className="text-gray-700 text-center mb-4">{message}</p>
+    {onRetry && (
+      <button
+        onClick={onRetry}
+        className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors"
+      >
+        Попробовать снова
+      </button>
+    )}
+  </div>
+);
 
 const ProfileEditorPage: React.FC = () => {
-  // In real app user id should come from auth context
-  const userId = 'user1';
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, loading, error, isAuthenticated, refreshUser } = useAuth();
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      navigate('/login', {
+        state: { from: location.pathname },
+        replace: true,
+      });
+    }
+  }, [loading, isAuthenticated, navigate, location]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+        e.returnValue =
+          'У вас есть несохраненные изменения. Вы уверены, что хотите покинуть страницу?';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  const handleRetry = () => {
+    refreshUser?.();
+  };
+
+  if (loading) {
+    return (
+      <StandardPageLayout
+        title="Редактирование профиля"
+        description="Настройте свой профиль и персональную информацию"
+      >
+        <LoadingSpinner />
+      </StandardPageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <StandardPageLayout
+        title="Ошибка загрузки профиля"
+        description="Произошла ошибка при загрузке данных профиля"
+      >
+        <ErrorMessage
+          message="Не удалось загрузить данные профиля. Проверьте подключение к интернету и попробуйте снова."
+          onRetry={handleRetry}
+        />
+      </StandardPageLayout>
+    );
+  }
+
+  if (!user || !isAuthenticated) {
+    return (
+      <StandardPageLayout
+        title="Доступ запрещен"
+        description="Необходима авторизация для доступа к этой странице"
+      >
+        <ErrorMessage message="Для редактирования профиля необходимо войти в систему." />
+      </StandardPageLayout>
+    );
+  }
+
   return (
-    <StandardPageLayout title="Редактирование профиля">
-      <ProfileEditor userId={userId} />
+    <StandardPageLayout
+      title="Редактирование профиля"
+      description="Настройте свой профиль и персональную информацию"
+      breadcrumbs={[
+        { label: 'Главная', href: '/' },
+        { label: 'Профиль', href: '/profile' },
+        { label: 'Редактирование', href: '/profile/edit' },
+      ]}
+    >
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Редактирование профиля</h1>
+          <p className="text-gray-600">Обновите свои личные данные и настройки аккаунта</p>
+        </div>
+
+        {hasUnsavedChanges && (
+          <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <span className="text-yellow-400">⚠️</span>
+              </div>
+              <div className="ml-3">
+                <p className="text-sm text-yellow-700">
+                  У вас есть несохраненные изменения. Не забудьте сохранить данные перед выходом.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <ProfileEditor
+          userId={user.id}
+          onUnsavedChanges={setHasUnsavedChanges}
+          onSaveSuccess={() => setHasUnsavedChanges(false)}
+          onError={err => console.error('Profile editor error:', err)}
+        />
+      </div>
     </StandardPageLayout>
   );
 };


### PR DESCRIPTION
## Summary
- add `useNotification` hook to display toast messages
- wrap application with `ToastProvider`
- replace `AccountSettingsPage` with dynamic version using auth and notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844876270d4832eadf79c73d38aac1f