### PR TITLE
Add advanced profile customization

### DIFF
--- a/components/ButtonLinkEditor.tsx
+++ b/components/ButtonLinkEditor.tsx
@@ -3,16 +3,16 @@ import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
 
 interface Props {
   value: string;
-  onChange: (val: string) => void;
-  maxLength?: number;
-  placeholder?: string;
+  url: string;
+  onTextChange: (val: string) => void;
+  onUrlChange: (val: string) => void;
 }
 
-export const ButtonLinkEditor: React.FC<Props> = ({ value, onChange, maxLength = 30, placeholder }) => {
+export const ButtonLinkEditor: React.FC<Props> = ({ value, url, onTextChange, onUrlChange }) => {
   const [showPicker, setShowPicker] = useState(false);
 
   const handleEmoji = (emojiData: EmojiClickData) => {
-    onChange(value + emojiData.emoji);
+    onTextChange(value + emojiData.emoji);
   };
 
   return (
@@ -20,10 +20,16 @@ export const ButtonLinkEditor: React.FC<Props> = ({ value, onChange, maxLength =
       <input
         type="text"
         value={value}
-        onChange={(e) => onChange(e.target.value)}
-        maxLength={maxLength}
-        placeholder={placeholder}
+        onChange={(e) => onTextChange(e.target.value)}
+        placeholder="Текст кнопки"
         className="border px-2 py-1 rounded w-full"
+      />
+      <input
+        type="url"
+        value={url}
+        onChange={(e) => onUrlChange(e.target.value)}
+        placeholder="https://example.com"
+        className="border px-2 py-1 rounded w-full mt-1"
       />
       <button type="button" className="px-2 py-1 bg-gray-200 rounded" onClick={() => setShowPicker(!showPicker)}>
         😊

--- a/components/SlugEditor.tsx
+++ b/components/SlugEditor.tsx
@@ -1,54 +1,36 @@
-import React, { useEffect, useState } from 'react';
-import slugify from 'slugify';
-import { checkSlugUnique } from '../services/slugService';
+import React from 'react';
 
 interface Props {
+  value: string;
+  onChange: (val: string) => void;
+  valid: boolean | null;
   base?: string;
 }
 
-export const SlugEditor: React.FC<Props> = ({ base = 'https://example.com/' }) => {
-  const [input, setInput] = useState('');
-  const [slug, setSlug] = useState('');
-  const [status, setStatus] = useState<'idle' | 'checking' | 'ok' | 'error'>('idle');
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    const s = slugify(input, { lower: true, strict: true });
-    setSlug(s);
-  }, [input]);
-
-  useEffect(() => {
-    if (!slug) return;
-    setStatus('checking');
-    checkSlugUnique(slug)
-      .then((r) => setStatus(r.unique ? 'ok' : 'error'))
-      .catch(() => setStatus('error'));
-  }, [slug]);
-
+export const SlugEditor: React.FC<Props> = ({ value, onChange, valid, base = 'https://example.com/' }) => {
   const copy = () => {
-    navigator.clipboard.writeText(base + slug);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard.writeText(base + value);
   };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       <input
         type="text"
-        value={input}
-        placeholder="Ваш URL"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
         className="border px-2 py-1 rounded w-full"
-        onChange={(e) => setInput(e.target.value)}
+        placeholder="Адрес"
       />
-      <div className="flex items-center gap-2">
-        <span className="text-sm">{base + slug}</span>
-        <button className="px-2 py-1 text-sm bg-gray-200 rounded" onClick={copy}>
+      <div className="flex items-center gap-2 text-sm">
+        <span>{base + value}</span>
+        <button className="px-2 py-1 bg-gray-200 rounded" onClick={copy}>
           Копировать
         </button>
-        {status === 'checking' && <span className="text-gray-500 text-sm">...</span>}
-        {status === 'ok' && <span className="text-green-600 text-sm">Свободен</span>}
-        {status === 'error' && <span className="text-red-600 text-sm">Занят</span>}
-        {copied && <span className="text-blue-600 text-sm">Скопировано</span>}
+        {valid === null ? null : valid ? (
+          <span className="text-green-600">Свободен</span>
+        ) : (
+          <span className="text-red-600">Занят</span>
+        )}
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.80.6",
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^19.1.0",
         "react-easy-crop": "^5.4.2",
         "react-markdown": "^10.1.0",
@@ -88,7 +89,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1388,6 +1388,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1442,6 +1452,18 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/unist": {
@@ -2328,6 +2350,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css.escape": {
@@ -3687,6 +3718,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4347,7 +4393,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4508,7 +4553,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4714,6 +4758,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5256,7 +5306,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5689,7 +5738,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5701,7 +5749,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -5762,6 +5809,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -5769,6 +5822,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -5801,9 +5908,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -5889,6 +5994,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6650,6 +6764,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.80.6",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^19.1.0",
     "react-easy-crop": "^5.4.2",
     "react-markdown": "^10.1.0",

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { AvatarUploader } from '../components/AvatarUploader';
 import { CoverUploader } from '../components/CoverUploader';
@@ -7,32 +7,231 @@ import { ButtonLinkEditor } from '../components/ButtonLinkEditor';
 import { RichTextEditor } from '../components/RichTextEditor';
 import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { Toast } from '../components/Toast';
-import { registerSlug } from '../services/slugService';
+import { fetchProfile, saveProfile, ProfileData } from '../services/profileService';
+import { checkSlugUnique } from '../services/slugService';
+import { Button } from '../ui/Button';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+
+const BLOCK_TYPES = [
+  { type: 'button', label: 'Кнопка', default: { text: 'Ссылка', url: '#', style: 'primary' } },
+  { type: 'text', label: 'Текст', default: { text: 'Новый текст' } },
+  { type: 'divider', label: 'Разделитель', default: {} },
+];
+
+const RESERVED_SLUGS = ['admin', 'login', 'me', 'profile'];
 
 const ProfileCustomizationPage: React.FC = () => {
-  const [slug, setSlug] = useState('');
-  const [buttonText, setButtonText] = useState('');
-  const [description, setDescription] = useState('');
-  const [layout, setLayout] = useState('feed');
+  const [profile, setProfile] = useState<ProfileData>({
+    avatar: null,
+    cover: null,
+    slug: '',
+    layout: 'feed',
+    color: '#2f80ed',
+    blocks: [],
+  });
+  const [slugValid, setSlugValid] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
-  const save = () => {
-    registerSlug(slug);
-    setToast('Сохранено');
+  useEffect(() => {
+    setLoading(true);
+    fetchProfile().then((data) => {
+      setProfile(data);
+      setLoading(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!profile.slug) return setSlugValid(null);
+    if (!/^[a-zA-Z0-9-_]{3,20}$/.test(profile.slug) || RESERVED_SLUGS.includes(profile.slug)) {
+      setSlugValid(false);
+      return;
+    }
+    let cancelled = false;
+    checkSlugUnique(profile.slug)
+      .then((r) => {
+        if (!cancelled) setSlugValid(r.unique);
+      })
+      .catch(() => !cancelled && setSlugValid(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [profile.slug]);
+
+  const addBlock = (type: string) => {
+    const blockType = BLOCK_TYPES.find((b) => b.type === type);
+    if (!blockType) return;
+    setProfile((p) => ({ ...p, blocks: [...p.blocks, { type, ...blockType.default }] }));
   };
+
+  const removeBlock = (index: number) => {
+    setProfile((p) => ({ ...p, blocks: p.blocks.filter((_, i) => i !== index) }));
+  };
+
+  const updateBlock = (index: number, props: any) => {
+    setProfile((p) => ({
+      ...p,
+      blocks: p.blocks.map((b, i) => (i === index ? { ...b, ...props } : b)),
+    }));
+  };
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const newBlocks = Array.from(profile.blocks);
+    const [removed] = newBlocks.splice(result.source.index, 1);
+    newBlocks.splice(result.destination.index, 0, removed);
+    setProfile((p) => ({ ...p, blocks: newBlocks }));
+  };
+
+  const handleSave = async () => {
+    if (!slugValid) {
+      setToast('Некорректный адрес профиля');
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveProfile(profile);
+      setToast('Профиль сохранён!');
+    } catch {
+      setToast('Ошибка сохранения');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <StandardPageLayout title="Персонализация профиля">
+        <div className="py-16 text-center text-gray-500 text-lg">Загрузка…</div>
+      </StandardPageLayout>
+    );
+  }
 
   return (
     <StandardPageLayout title="Персонализация профиля">
-      <div className="space-y-6">
-        <AvatarUploader />
-        <CoverUploader />
-        <SlugEditor base="https://basis.app/" />
-        <ButtonLinkEditor value={buttonText} onChange={setButtonText} placeholder="Текст кнопки" />
-        <RichTextEditor value={description} onChange={setDescription} />
-        <ProfileLayoutSelector value={layout} onChange={setLayout} />
-        <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={save}>
-          Сохранить
-        </button>
+      <div className="flex flex-col lg:flex-row gap-8">
+        <aside className="w-full lg:w-1/3 space-y-5">
+          <AvatarUploader onChange={(avatar) => setProfile((p) => ({ ...p, avatar }))} />
+          <CoverUploader onChange={(cover) => setProfile((p) => ({ ...p, cover }))} />
+          <SlugEditor
+            value={profile.slug}
+            onChange={(slug) => setProfile((p) => ({ ...p, slug: slug.replace(/\s+/g, '-').toLowerCase() }))}
+            valid={slugValid}
+            base="https://basis.app/"
+          />
+          <div>
+            <label className="block font-semibold mb-1">Блоки профиля</label>
+            <DragDropContext onDragEnd={onDragEnd}>
+              <Droppable droppableId="blocks">
+                {(provided) => (
+                  <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-2">
+                    {profile.blocks.map((block, i) => (
+                      <Draggable key={i} draggableId={String(i)} index={i}>
+                        {(provided) => (
+                          <div
+                            className="bg-gray-50 border rounded p-2 mb-1 relative"
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                          >
+                            <div className="flex justify-between items-center mb-2">
+                              <span className="text-xs uppercase">{block.type}</span>
+                              <Button onClick={() => removeBlock(i)} className="text-red-600 p-1 text-xs">
+                                ×
+                              </Button>
+                            </div>
+                            {block.type === 'button' && (
+                              <ButtonLinkEditor
+                                value={block.text}
+                                url={block.url}
+                                onTextChange={(text) => updateBlock(i, { text })}
+                                onUrlChange={(url) => updateBlock(i, { url })}
+                              />
+                            )}
+                            {block.type === 'text' && (
+                              <RichTextEditor value={block.text} onChange={(text) => updateBlock(i, { text })} />
+                            )}
+                            {block.type === 'divider' && <hr className="my-2 border-gray-300" />}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+            <div className="flex gap-2 mt-2">
+              {BLOCK_TYPES.map((b) => (
+                <Button key={b.type} onClick={() => addBlock(b.type)} className="p-2 text-xs bg-gray-200 hover:bg-indigo-200">
+                  {b.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <ProfileLayoutSelector value={profile.layout} onChange={(layout) => setProfile((p) => ({ ...p, layout }))} />
+          <div>
+            <label className="block mb-1 font-semibold">Цветовая тема</label>
+            <input
+              type="color"
+              className="w-12 h-8 border rounded"
+              value={profile.color}
+              onChange={(e) => setProfile((p) => ({ ...p, color: e.target.value }))}
+            />
+          </div>
+          <Button onClick={handleSave} disabled={saving || !slugValid} className="mt-6 px-5 py-3 w-full bg-indigo-600 text-white rounded font-bold">
+            {saving ? 'Сохраняем…' : 'Сохранить профиль'}
+          </Button>
+        </aside>
+        <main className="flex-1 bg-white rounded-xl border shadow p-6">
+          <div className="overflow-hidden rounded-xl border mb-6">
+            {profile.cover && <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />}
+            <div className="p-4 text-center relative">
+              {profile.avatar && (
+                <img
+                  src={profile.avatar}
+                  alt="avatar"
+                  className="w-24 h-24 rounded-full border-4 border-white shadow absolute left-1/2 -translate-x-1/2 -top-12 bg-white"
+                />
+              )}
+              <div className="mt-16">
+                <div className="font-bold text-xl mb-1">/u/{profile.slug || 'ваш-адрес'}</div>
+                <div className={`flex flex-col gap-2 mt-3 ${profile.layout === 'grid' ? 'md:grid md:grid-cols-2' : ''}`}>
+                  {profile.blocks.map((block, i) =>
+                    block.type === 'button' ? (
+                      <a
+                        key={i}
+                        href={block.url}
+                        target="_blank"
+                        rel="noopener"
+                        className={`block px-4 py-2 text-center rounded font-semibold transition-colors ${
+                          block.style === 'primary'
+                            ? 'bg-green-500 text-white hover:bg-green-600'
+                            : block.style === 'secondary'
+                            ? 'bg-blue-500 text-white hover:bg-blue-600'
+                            : 'border-2 border-gray-400 text-gray-800 hover:bg-gray-100'
+                        }`}
+                        style={{ background: block.style === 'primary' ? profile.color : undefined }}
+                      >
+                        {block.text}
+                      </a>
+                    ) : block.type === 'text' ? (
+                      <div key={i} className="px-3 py-2 text-gray-800 text-left" dangerouslySetInnerHTML={{ __html: block.text }} />
+                    ) : block.type === 'divider' ? (
+                      <hr key={i} className="border-gray-300 my-2" />
+                    ) : null
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="text-xs text-gray-500 text-center">
+            <a href={`/u/${profile.slug}`} target="_blank" rel="noopener" className="underline hover:text-indigo-600">
+              Перейти к своей странице →
+            </a>
+          </div>
+        </main>
       </div>
       {toast && <Toast message={toast} onClose={() => setToast(null)} />}
     </StandardPageLayout>

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -1,0 +1,35 @@
+export interface ProfileData {
+  avatar: string | null;
+  cover: string | null;
+  slug: string;
+  layout: string;
+  color: string;
+  blocks: Array<{ type: string; text?: string; url?: string; style?: string }>;
+}
+
+const STORAGE_KEY = 'profileCustomization';
+
+export async function fetchProfile(): Promise<ProfileData> {
+  await new Promise((r) => setTimeout(r, 300));
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      return JSON.parse(raw) as ProfileData;
+    } catch {
+      /* ignore */
+    }
+  }
+  return {
+    avatar: null,
+    cover: null,
+    slug: '',
+    layout: 'feed',
+    color: '#2f80ed',
+    blocks: [],
+  };
+}
+
+export async function saveProfile(data: ProfileData): Promise<void> {
+  await new Promise((r) => setTimeout(r, 300));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}


### PR DESCRIPTION
## Summary
- add drag and drop blocks and color theme in profile customization
- provide mock `profileService` for saving/loading data
- extend slug editor and button link editor
- install `react-beautiful-dnd`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684493d32df0832e901b1592ebb0f3d4