### PR TITLE
Fix lint warnings

### DIFF
--- a/pages/AiDemoPage.tsx
+++ b/pages/AiDemoPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { useGenerateProfile } from '../hooks/useGenerateProfile';
 import { Button } from '../ui/Button';
+import type { GeneratedProfile } from '../services/ai';
 
 type GenerateInput = {
   goals: string;
@@ -10,10 +11,15 @@ type GenerateInput = {
 
 const initialInput: GenerateInput = { goals: '', description: '' };
 
+type HistoryItem = {
+  input: GenerateInput;
+  result: GeneratedProfile;
+};
+
 const AiDemoPage: React.FC = () => {
   const { loading, data, error, run } = useGenerateProfile();
   const [input, setInput] = useState<GenerateInput>(initialInput);
-  const [history, setHistory] = useState<any[]>([]);
+  const [history, setHistory] = useState<HistoryItem[]>([]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -2,13 +2,20 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import StandardPageLayout from "../layouts/StandardPageLayout";
 import { Skeleton } from "../components/Skeleton";
-import { fetchCases, fetchStats, fetchReviews } from "../api/home";
+import {
+  fetchCases,
+  fetchStats,
+  fetchReviews,
+  type HomeCase,
+  type HomeStats,
+  type HomeReview,
+} from "../api/home";
 
 const HomePage: React.FC = () => {
   const [loading, setLoading] = useState(true);
-  const [cases, setCases] = useState<any[]>([]);
-  const [stats, setStats] = useState<any>(null);
-  const [reviews, setReviews] = useState<any[]>([]);
+  const [cases, setCases] = useState<HomeCase[]>([]);
+  const [stats, setStats] = useState<HomeStats | null>(null);
+  const [reviews, setReviews] = useState<HomeReview[]>([]);
   const [email, setEmail] = useState("");
   const [subscribed, setSubscribed] = useState(false);
 
@@ -288,9 +295,9 @@ const HomePage: React.FC = () => {
               &copy; {new Date().getFullYear()} Basis Platform. Все права защищены.
             </p>
             <div className="flex gap-4">
-              <a href="https://twitter.com/" target="_blank" rel="noopener" aria-label="Twitter" className="hover:text-gray-700">Twitter</a>
-              <a href="https://linkedin.com/" target="_blank" rel="noopener" aria-label="LinkedIn" className="hover:text-gray-700">LinkedIn</a>
-              <a href="https://t.me/" target="_blank" rel="noopener" aria-label="Telegram" className="hover:text-gray-700">Telegram</a>
+              <a href="https://twitter.com/" target="_blank" rel="noopener noreferrer" aria-label="Twitter" className="hover:text-gray-700">Twitter</a>
+              <a href="https://linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" className="hover:text-gray-700">LinkedIn</a>
+              <a href="https://t.me/" target="_blank" rel="noopener noreferrer" aria-label="Telegram" className="hover:text-gray-700">Telegram</a>
             </div>
             <div className="text-xs text-gray-400 mt-1">Сделано с ♥ в Rara Avis</div>
           </div>

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -204,7 +204,7 @@ const ProfileCustomizationPage: React.FC = () => {
                         key={i}
                         href={block.url}
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         className={`block px-4 py-2 text-center rounded font-semibold transition-colors ${
                           block.style === 'primary'
                             ? 'bg-green-500 text-white hover:bg-green-600'
@@ -227,7 +227,7 @@ const ProfileCustomizationPage: React.FC = () => {
             </div>
           </div>
           <div className="text-xs text-gray-500 text-center">
-            <a href={`/u/${profile.slug}`} target="_blank" rel="noopener" className="underline hover:text-indigo-600">
+            <a href={`/u/${profile.slug}`} target="_blank" rel="noopener noreferrer" className="underline hover:text-indigo-600">
               Перейти к своей странице →
             </a>
           </div>


### PR DESCRIPTION
## Summary
- add explicit types for home page state
- fix missing `noopener noreferrer`
- type AI demo history items

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2e46ba8832e8f8a1ee71eaf930d