### PR TITLE
Refactor profile slug logic

### DIFF
--- a/hooks/useSlugValidation.ts
+++ b/hooks/useSlugValidation.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { checkSlugUnique } from '../services/slugService';
+
+export function useSlugValidation(slug: string, reserved: string[] = []) {
+  const [valid, setValid] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setValid(null);
+      return;
+    }
+    if (!/^[a-zA-Z0-9-_]{3,20}$/.test(slug) || reserved.includes(slug)) {
+      setValid(false);
+      return;
+    }
+    let cancelled = false;
+    checkSlugUnique(slug)
+      .then(r => {
+        if (!cancelled) setValid(r.unique);
+      })
+      .catch(() => {
+        if (!cancelled) setValid(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, reserved]);
+
+  return valid;
+}

--- a/pages/PersonalizationPage.tsx
+++ b/pages/PersonalizationPage.tsx
@@ -1,56 +1,31 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import StandardPageLayout from '../layouts/StandardPageLayout';
-import { Button } from '../ui/Button';
+import { AvatarUploader } from '../components/AvatarUploader';
+import { CoverUploader } from '../components/CoverUploader';
+import { SlugEditor } from '../components/SlugEditor';
+import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { RichTextEditor } from '../components/RichTextEditor';
+import { Button } from '../ui/Button';
+import { useSlugValidation } from '../hooks/useSlugValidation';
 
-const takenSlugs = ['admin', 'test', 'profile'];
-
-const checkSlugAvailability = async (slug: string) => {
-  await new Promise((res) => setTimeout(res, 300));
-  return !takenSlugs.includes(slug.toLowerCase());
-};
+const RESERVED_SLUGS = ['admin', 'test', 'profile'];
 
 const PersonalizationPage: React.FC = () => {
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [coverPreview, setCoverPreview] = useState<string | null>(null);
   const [slug, setSlug] = useState('');
-  const [slugValid, setSlugValid] = useState<boolean | null>(null);
+  const slugValid = useSlugValidation(slug, RESERVED_SLUGS);
   const [layout, setLayout] = useState<'feed' | 'grid' | 'cards'>('feed');
-  const layoutOptions = ['feed', 'grid', 'cards'] as const;
   const [blocks, setBlocks] = useState<string[]>([
     'Кнопка 1',
     'Кнопка 2',
     'Кнопка 3',
   ]);
 
-  useEffect(() => {
-    if (!slug) {
-      setSlugValid(null);
-      return;
-    }
-    const id = setTimeout(() => {
-      checkSlugAvailability(slug).then(setSlugValid);
-    }, 400);
-    return () => clearTimeout(id);
-  }, [slug]);
 
   const copySlug = () => {
     const url = `${window.location.origin}/u/${slug}`;
     navigator.clipboard.writeText(url);
-  };
-
-  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setAvatarPreview(URL.createObjectURL(file));
-    }
-  };
-
-  const handleCoverChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setCoverPreview(URL.createObjectURL(file));
-    }
   };
 
   const updateBlock = (index: number, val: string) => {
@@ -76,46 +51,14 @@ const PersonalizationPage: React.FC = () => {
     <StandardPageLayout title="Редактор персонализации">
       <div className="flex flex-col lg:flex-row gap-6">
         <aside className="w-full lg:w-1/3 space-y-4">
-          <div>
-            <label className="block mb-1 font-medium">Аватар</label>
-            <input type="file" accept="image/*" onChange={handleAvatarChange} />
-            {avatarPreview && (
-              <img
-                src={avatarPreview}
-                alt="avatar"
-                className="mt-2 w-24 h-24 object-cover rounded-full"
-              />
-            )}
-          </div>
-          <div>
-            <label className="block mb-1 font-medium">Обложка</label>
-            <input type="file" accept="image/*" onChange={handleCoverChange} />
-            {coverPreview && (
-              <img
-                src={coverPreview}
-                alt="cover"
-                className="mt-2 w-full h-24 object-cover rounded"
-              />
-            )}
-          </div>
-          <div>
-            <label className="block mb-1 font-medium">Адрес профиля</label>
-            <div className="flex items-center gap-2">
-              <input
-                className="flex-1 p-2 border rounded"
-                value={slug}
-                onChange={(e) => setSlug(e.target.value)}
-              />
-              {slug && slugValid !== null && (
-                <span className={slugValid ? 'text-green-600' : 'text-red-600'}>
-                  {slugValid ? 'Свободен' : 'Занят'}
-                </span>
-              )}
-              <Button onClick={copySlug} className="px-2 py-1">
-                Копировать
-              </Button>
-            </div>
-          </div>
+          <AvatarUploader onChange={setAvatarPreview} />
+          <CoverUploader onChange={setCoverPreview} />
+          <SlugEditor
+            value={slug}
+            onChange={setSlug}
+            valid={slugValid}
+            base="https://basis.app/"
+          />
           <div className="space-y-4">
             {blocks.map((val, i) => (
               <div key={i}>
@@ -127,22 +70,7 @@ const PersonalizationPage: React.FC = () => {
               </div>
             ))}
           </div>
-          <div>
-            <label className="block mb-1 font-medium">Структура профиля</label>
-            <div className="flex items-center gap-2">
-              {layoutOptions.map((opt) => (
-                <label key={opt} className="flex items-center gap-1">
-                  <input
-                    type="radio"
-                    value={opt}
-                    checked={layout === opt}
-                    onChange={() => setLayout(opt)}
-                  />
-                  {opt}
-                </label>
-              ))}
-            </div>
-          </div>
+          <ProfileLayoutSelector value={layout} onChange={setLayout} />
         </aside>
         <main className="flex-1">
           <div className="border rounded overflow-hidden">

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -8,7 +8,7 @@ import { RichTextEditor } from '../components/RichTextEditor';
 import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { Toast } from '../components/Toast';
 import { fetchProfile, saveProfile, ProfileData } from '../services/profileService';
-import { checkSlugUnique } from '../services/slugService';
+import { useSlugValidation } from '../hooks/useSlugValidation';
 import { Button } from '../ui/Button';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
@@ -29,7 +29,7 @@ const ProfileCustomizationPage: React.FC = () => {
     color: '#2f80ed',
     blocks: [],
   });
-  const [slugValid, setSlugValid] = useState<boolean | null>(null);
+  const slugValid = useSlugValidation(profile.slug, RESERVED_SLUGS);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -42,22 +42,6 @@ const ProfileCustomizationPage: React.FC = () => {
     });
   }, []);
 
-  useEffect(() => {
-    if (!profile.slug) return setSlugValid(null);
-    if (!/^[a-zA-Z0-9-_]{3,20}$/.test(profile.slug) || RESERVED_SLUGS.includes(profile.slug)) {
-      setSlugValid(false);
-      return;
-    }
-    let cancelled = false;
-    checkSlugUnique(profile.slug)
-      .then((r) => {
-        if (!cancelled) setSlugValid(r.unique);
-      })
-      .catch(() => !cancelled && setSlugValid(false));
-    return () => {
-      cancelled = true;
-    };
-  }, [profile.slug]);
 
   const addBlock = (type: string) => {
     const blockType = BLOCK_TYPES.find((b) => b.type === type);


### PR DESCRIPTION
## Summary
- add `useSlugValidation` hook for shared slug check
- refactor `PersonalizationPage` to use shared components and hook
- update `ProfileCustomizationPage` to reuse the new hook

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6844a8c289c4832e919bb0ace2440b3e