### PR TITLE
Исправление пропущенного slug

### DIFF
--- a/layouts/StandardPageLayout.tsx
+++ b/layouts/StandardPageLayout.tsx
@@ -17,7 +17,7 @@ const StandardPageLayout: React.FC<{
           </Link>
         </li>
         <li>
-          <Link to="/public-profile" className="text-blue-600 hover:underline">
+          <Link to="/public-profile/demo" className="text-blue-600 hover:underline">
             Public Profile (Current Design)
           </Link>
         </li>

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { ProfileSidebar } from '../components/ProfileSidebar';
 import { ProjectShowcaseGrid } from '../components/ProjectShowcaseGrid';
 import { PublishProfileButton } from '../components/PublishProfileButton';
@@ -121,6 +122,7 @@ const BottomRightShareBar: React.FC = () => {
 };
 
 const PublicProfilePage: React.FC = () => {
+  const { slug = '' } = useParams<{ slug: string }>();
   return (
     // main-content-area class gives the white bg and padding
     <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -22,7 +22,7 @@ export const routes: RouteObject[] = [
       { path: 'auth', element: <AuthPage /> },
       { path: 'dashboard', element: <DashboardPage /> },
       { path: 'editor', element: <EditorPage /> },
-      { path: 'public-profile', element: <PublicProfilePage /> },
+      { path: 'public-profile/:slug', element: <PublicProfilePage /> },
       { path: 'account', element: <AccountSettingsPage /> },
       { path: 'billing', element: <BillingPage /> },
       { path: 'analytics', element: <AnalyticsPage /> },


### PR DESCRIPTION
## Изменения
- получение `slug` на странице публичного профиля через параметры маршрута
- обновлён путь в роутере
- обновлена ссылка в примере навигации

## Проверка
- `npm test` *(падает из‑за отсутствующих зависимостей rollup)*

------
https://chatgpt.com/codex/tasks/task_e_6844a8ce0a48832e9eee5ecfd4d1024d