### PR TITLE
Improve loading states with spinners

### DIFF
--- a/pages/AccountSettingsPage.tsx
+++ b/pages/AccountSettingsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import useAuth from '../hooks/useAuth';
 import useNotification from '../hooks/useNotification';
+import Spinner from '../ui/Spinner';
 
 interface UserData {
   id: string;
@@ -371,8 +372,10 @@ const AccountSettingsPage: React.FC = () => {
                 <button
                   type="submit"
                   disabled={saving.profile}
-                  className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-busy={saving.profile}
+                  className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
                 >
+                  {saving.profile && <Spinner size="h-4 w-4" className="mr-2" />}
                   {saving.profile ? 'Сохранение...' : 'Сохранить изменения'}
                 </button>
               </div>
@@ -394,7 +397,8 @@ const AccountSettingsPage: React.FC = () => {
                         className="hidden"
                         id="avatar-upload"
                       />
-                      <label htmlFor="avatar-upload" className="cursor-pointer text-sm text-indigo-600 hover:underline">
+                      <label htmlFor="avatar-upload" className="cursor-pointer text-sm text-indigo-600 hover:underline flex items-center">
+                        {saving.avatar && <Spinner size="h-4 w-4" className="mr-1" />}
                         {saving.avatar ? 'Загрузка...' : 'Загрузить новый'}
                       </label>
                     </div>
@@ -455,8 +459,10 @@ const AccountSettingsPage: React.FC = () => {
                   <button
                     type="submit"
                     disabled={saving.password}
-                    className="px-4 py-2 bg-orange-500 text-white text-sm font-medium rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                    aria-busy={saving.password}
+                    className="px-4 py-2 bg-orange-500 text-white text-sm font-medium rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
                   >
+                    {saving.password && <Spinner size="h-4 w-4" className="mr-2" />}
                     {saving.password ? 'Изменение...' : 'Изменить пароль'}
                   </button>
                 </div>
@@ -473,8 +479,10 @@ const AccountSettingsPage: React.FC = () => {
               <button
                 onClick={toggle2FA}
                 disabled={saving.twoFactor}
-                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-busy={saving.twoFactor}
+                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
               >
+                {saving.twoFactor && <Spinner size="h-4 w-4" className="mr-2" />}
                 {saving.twoFactor ? 'Обновление...' : userData.twoFactorEnabled ? 'Отключить 2FA' : 'Включить 2FA'}
               </button>
             </div>
@@ -556,8 +564,10 @@ const AccountSettingsPage: React.FC = () => {
               <button
                 onClick={generateApiKey}
                 disabled={saving.apiKey}
-                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-busy={saving.apiKey}
+                className="px-4 py-2 border border-gray-300 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
               >
+                {saving.apiKey && <Spinner size="h-4 w-4" className="mr-2" />}
                 {saving.apiKey ? 'Генерация...' : 'Сгенерировать API-ключ'}
               </button>
             </div>

--- a/pages/AiDemoPage.tsx
+++ b/pages/AiDemoPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { useGenerateProfile } from '../hooks/useGenerateProfile';
 import { Button } from '../ui/Button';
+import Spinner from '../ui/Spinner';
 import type { GeneratedProfile } from '../services/ai';
 
 type GenerateInput = {
@@ -85,8 +86,10 @@ const AiDemoPage: React.FC = () => {
           <Button
             onClick={handleGenerate}
             disabled={loading || !input.goals.trim() || !input.description.trim()}
-            className="w-full"
+            aria-busy={loading}
+            className="w-full flex items-center justify-center"
           >
+            {loading && <Spinner size="h-4 w-4" className="mr-2" />}
             {loading ? 'AI генерирует…' : 'Сгенерировать'}
           </Button>
           {error && (

--- a/pages/AuthPage.tsx
+++ b/pages/AuthPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { useAuth } from '../contexts/AuthContext';
+import Spinner from '../ui/Spinner';
 
 type AuthMode = 'login' | 'signup' | 'reset';
 type AuthStatus = 'idle' | 'loading' | 'success' | 'error';
@@ -83,9 +84,10 @@ const AuthPage: React.FC = () => {
         setStatus('success');
         setSuccessMsg('Письмо для восстановления отправлено на почту.');
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Произошла ошибка. Проверьте данные и попробуйте снова.';
       setStatus('error');
-      setErrorMsg(err?.message || 'Произошла ошибка. Проверьте данные и попробуйте снова.');
+      setErrorMsg(message);
     }
   };
 
@@ -230,15 +232,17 @@ const AuthPage: React.FC = () => {
           <button
             type="submit"
             disabled={status === 'loading'}
+            aria-busy={status === 'loading'}
             className={`w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white ${
               mode === 'signup'
                 ? 'bg-green-600 hover:bg-green-700 focus:ring-green-500'
                 : mode === 'reset'
                 ? 'bg-orange-500 hover:bg-orange-600 focus:ring-orange-400'
                 : 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'
-            } focus:outline-none focus:ring-2 focus:ring-offset-2 transition`}
+            } focus:outline-none focus:ring-2 focus:ring-offset-2 transition flex items-center justify-center`}
             data-testid="auth-submit"
           >
+            {status === 'loading' && <Spinner size="h-4 w-4" className="mr-2" />}
             {status === 'loading'
               ? 'Обработка…'
               : mode === 'login'

--- a/pages/BillingPage.tsx
+++ b/pages/BillingPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/billing';
 import { Link } from 'react-router-dom';
 import useNotification from '../hooks/useNotification';
+import Spinner from '../ui/Spinner';
 
 const TariffCard = ({
   name,
@@ -76,9 +77,11 @@ const TariffCard = ({
       <button
         onClick={onSwitch}
         disabled={loading}
-        className={`w-full px-6 py-3 ${popular ? 'bg-green-500 hover:bg-green-600' : 'bg-indigo-600 hover:bg-indigo-700'} text-white font-semibold rounded-lg transition-colors`}
+        aria-busy={loading}
+        className={`w-full px-6 py-3 ${popular ? 'bg-green-500 hover:bg-green-600' : 'bg-indigo-600 hover:bg-indigo-700'} text-white font-semibold rounded-lg transition-colors flex items-center justify-center`}
         aria-label={`Переключиться на тариф ${name}`}
       >
+        {loading && <Spinner size="h-4 w-4" className="mr-2" />}
         {loading ? 'Переключаем...' : `Переключиться на ${name}`}
       </button>
     )}
@@ -158,8 +161,9 @@ const BillingPage: React.FC = () => {
       showNotification('Тариф успешно переключён!', 'success');
       const b = await getBillingInfo();
       setBillingInfo(b);
-    } catch (e: any) {
-      showNotification(e?.message || 'Ошибка переключения тарифа', 'error');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Ошибка переключения тарифа';
+      showNotification(message, 'error');
     } finally {
       setTariffLoading(null);
     }
@@ -172,8 +176,9 @@ const BillingPage: React.FC = () => {
       showNotification('Способ оплаты обновлён', 'success');
       const b = await getBillingInfo();
       setBillingInfo(b);
-    } catch (e: any) {
-      showNotification(e?.message || 'Ошибка обновления оплаты', 'error');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Ошибка обновления оплаты';
+      showNotification(message, 'error');
     } finally {
       setPayMethodLoading(false);
     }
@@ -184,9 +189,10 @@ const BillingPage: React.FC = () => {
     try {
       await toggleAutoRenew(!autoRenew);
       showNotification(`Автопродление ${!autoRenew ? 'включено' : 'отключено'}`, 'success');
-    } catch (e: any) {
+    } catch (e: unknown) {
       setAutoRenew((prev) => !prev);
-      showNotification(e?.message || 'Ошибка смены автопродления', 'error');
+      const message = e instanceof Error ? e.message : 'Ошибка смены автопродления';
+      showNotification(message, 'error');
     }
   };
 
@@ -230,11 +236,12 @@ const BillingPage: React.FC = () => {
                 {billingInfo?.paymentMethod || 'Не задан'}
               </p>
               <button
-                className="text-sm text-indigo-600 hover:underline mt-1"
+                className="text-sm text-indigo-600 hover:underline mt-1 flex items-center"
                 disabled={payMethodLoading}
                 onClick={handleUpdatePayMethod}
                 aria-busy={payMethodLoading}
               >
+                {payMethodLoading && <Spinner size="h-4 w-4" className="mr-1" />}
                 {payMethodLoading ? 'Обновляем...' : 'Изменить способ оплаты'}
               </button>
             </div>

--- a/pages/EditorPage.tsx
+++ b/pages/EditorPage.tsx
@@ -3,6 +3,7 @@ import StandardPageLayout from '../layouts/StandardPageLayout';
 import { Tooltip } from '../components/Tooltip';
 import { Onboarding } from '../components/Onboarding';
 import { useToast } from '../components/ToastProvider';
+import Spinner from '../ui/Spinner';
 
 // --- Базовые типы блоков ---
 const BLOCK_TYPES = [
@@ -232,19 +233,23 @@ const EditorPage: React.FC = () => {
             <div className="flex items-center space-x-2">
               <Tooltip text="Сохранить изменения">
                 <button
-                  className="px-3 py-1.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600"
+                  className="px-3 py-1.5 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 flex items-center justify-center"
                   onClick={handleSave}
                   disabled={saving}
+                  aria-busy={saving}
                 >
+                  {saving && <Spinner size="h-4 w-4" className="mr-1" />}
                   {saving ? 'Сохраняем...' : 'Сохранить'}
                 </button>
               </Tooltip>
               <Tooltip text="Опубликовать страницу">
                 <button
-                  className="px-3 py-1.5 text-xs bg-green-500 text-white rounded hover:bg-green-600"
+                  className="px-3 py-1.5 text-xs bg-green-500 text-white rounded hover:bg-green-600 flex items-center justify-center"
                   onClick={handlePublish}
                   disabled={publishing}
+                  aria-busy={publishing}
                 >
+                  {publishing && <Spinner size="h-4 w-4" className="mr-1" />}
                   {publishing ? 'Публикуем...' : 'Опубликовать'}
                 </button>
               </Tooltip>

--- a/pages/LegalPage.tsx
+++ b/pages/LegalPage.tsx
@@ -140,14 +140,19 @@ const LegalPage: React.FC = () => {
   const [search, setSearch] = useState("");
 
   // Фильтрация по поиску
-  const filteredSections = SECTIONS.filter(
-    (s) =>
+  const filteredSections = SECTIONS.filter((s) => {
+    const content = SECTION_CONTENT[s.id];
+    const text =
+      typeof content === 'string'
+        ? content
+        : React.isValidElement(content)
+        ? React.Children.toArray(content.props.children).join('')
+        : '';
+    return (
       s.title.toLowerCase().includes(search.toLowerCase()) ||
-      (SECTION_CONTENT[s.id] as any)?.props?.children
-        ?.toString()
-        ?.toLowerCase()
-        .includes(search.toLowerCase())
-  );
+      text.toLowerCase().includes(search.toLowerCase())
+    );
+  });
 
   return (
     <StandardPageLayout title="Правовые документы и политика платформы Basis">

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -10,6 +10,7 @@ import { Toast } from '../components/Toast';
 import { fetchProfile, saveProfile, ProfileData } from '../services/profileService';
 import { checkSlugUnique } from '../services/slugService';
 import { Button } from '../ui/Button';
+import Spinner from '../ui/Spinner';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
 const BLOCK_TYPES = [
@@ -69,7 +70,7 @@ const ProfileCustomizationPage: React.FC = () => {
     setProfile((p) => ({ ...p, blocks: p.blocks.filter((_, i) => i !== index) }));
   };
 
-  const updateBlock = (index: number, props: any) => {
+  const updateBlock = (index: number, props: Record<string, unknown>) => {
     setProfile((p) => ({
       ...p,
       blocks: p.blocks.map((b, i) => (i === index ? { ...b, ...props } : b)),
@@ -180,7 +181,13 @@ const ProfileCustomizationPage: React.FC = () => {
               onChange={(e) => setProfile((p) => ({ ...p, color: e.target.value }))}
             />
           </div>
-          <Button onClick={handleSave} disabled={saving || !slugValid} className="mt-6 px-5 py-3 w-full bg-indigo-600 text-white rounded font-bold">
+          <Button
+            onClick={handleSave}
+            disabled={saving || !slugValid}
+            aria-busy={saving}
+            className="mt-6 px-5 py-3 w-full bg-indigo-600 text-white rounded font-bold flex items-center justify-center"
+          >
+            {saving && <Spinner size="h-4 w-4" className="mr-2" />}
             {saving ? 'Сохраняем…' : 'Сохранить профиль'}
           </Button>
         </aside>

--- a/ui/Spinner.tsx
+++ b/ui/Spinner.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export interface SpinnerProps {
+  size?: string;
+  className?: string;
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 'h-5 w-5', className = '' }) => (
+  <div className={`animate-spin rounded-full border-b-2 border-current ${size} ${className}`} />
+);
+
+export default Spinner;


### PR DESCRIPTION
## Summary
- add small `Spinner` component
- block form buttons while saving with aria-busy and spinners
- handle errors without `any` types
- update search in LegalPage

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844a8d9cc28832e942fd993bdd685e6