### PR TITLE
Fix registration 404 error

### DIFF
--- a/pages/LegalPage.tsx
+++ b/pages/LegalPage.tsx
@@ -140,7 +140,14 @@ const LegalPage: React.FC = () => {
   const [search, setSearch] = useState("");
 
   // Фильтрация по поиску
-  const filteredSections = SECTIONS.filter((s) => {
+const filteredSections = SECTIONS.filter(
+  (s) =>
+    s.title.toLowerCase().includes(search.toLowerCase()) ||
+    (SECTION_CONTENT[s.id] as any)?.props?.children
+      ?.toString()
+      ?.toLowerCase()
+      .includes(search.toLowerCase())
+);
 
   return (
     <StandardPageLayout title="Правовые документы и политика платформы Basis">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig(({ mode }) => {
         '@': path.resolve(__dirname, '.'),
       },
     },
+    server: {
+      proxy: {
+        '/api': 'http://localhost:3001',
+        '/oauth': 'http://localhost:3001',
+        '/graphql': 'http://localhost:3001',
+        '/docs': 'http://localhost:3001',
+      },
+    },
     optimizeDeps: {
       include: ['zod'],
     },


### PR DESCRIPTION
## Summary
- restore missing filter logic in `LegalPage`
- add dev server proxy settings so `/api` routes hit the backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ad6e85a8832ebabe6e6c48634c95