### PR TITLE
Fix slug check endpoint and tsconfig

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -27,8 +27,6 @@ const users: Record<string, { id: string; password: string }> = {
   test: { id: 'test', password: 'testpass' },
 };
 
-const reservedSlugs = ['admin', 'login', 'me', 'profile'];
-const usedSlugs = new Set<string>();
 
 const oauth = new OAuth2Server({
   model: {
@@ -124,6 +122,13 @@ app.post('/api/login', (req, res) => {
 
 // Slug endpoints
 app.get('/api/check-slug', (req, res) => {
+  const slug = String(req.query.slug || '').toLowerCase();
+  if (!slug) {
+    res.status(400).json({ error: 'Missing slug' });
+    return;
+  }
+  const available = !RESERVED_SLUGS.has(slug) && !usedSlugs.has(slug);
+  res.status(available ? 200 : 409).json({ available });
 });
 
 // GraphQL setup

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
 
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
## Summary
- clean up duplicate slug variables and implement slug availability endpoint
- remove unsupported compiler option from tsconfig

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844af9d1ba8832ebea1594bca42d484