### PR TITLE
Fix Tailwind setup and add missing API routes

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --color-bg: #ffffff;
   --color-text: #111111;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Basis Platform</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/server/index.ts
+++ b/server/index.ts
@@ -169,6 +169,117 @@ app.post('/webhook/event', (req, res) => {
   res.sendStatus(200);
 });
 
+// Simplified demo endpoints for the frontend
+app.get('/api/home', (_req, res) => {
+  const cases = [
+    {
+      id: '1',
+      title: 'Дизайнерское портфолио',
+      desc: 'Пример стильной страницы для креативных работ',
+      preview: 'https://placehold.co/600x400/png',
+      username: 'designer',
+    },
+    {
+      id: '2',
+      title: 'Профиль разработчика',
+      desc: 'Техническое портфолио с ссылками на проекты',
+      preview: 'https://placehold.co/600x400/png',
+      username: 'dev',
+    },
+    {
+      id: '3',
+      title: 'Личный блог',
+      desc: 'Пример странички для контент‑криэйтора',
+      preview: 'https://placehold.co/600x400/png',
+      username: 'blogger',
+    },
+  ];
+  const stats = { users: 1200, pages: 3400, integrations: 12 };
+  const reviews = [
+    {
+      id: '1',
+      name: 'Анна',
+      job: 'Дизайнер',
+      avatar: 'https://placehold.co/80/png',
+      text: 'Очень удобный сервис, создала портфолио за пару минут!',
+      stars: 5,
+    },
+    {
+      id: '2',
+      name: 'Иван',
+      job: 'Разработчик',
+      avatar: 'https://placehold.co/80/png',
+      text: 'Интеграции работают отлично, сайт загрузил код без проблем.',
+      stars: 4,
+    },
+  ];
+  res.json({ cases, stats, reviews });
+});
+
+app.get('/api/billing', (_req, res) => {
+  const tariffs = [
+    {
+      id: 'free',
+      name: 'Free',
+      price: '0₽',
+      features: ['1 страница', 'Базовые блоки', 'Поддержка Basis'],
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      price: '499₽',
+      features: [
+        '10 страниц',
+        'Все блоки',
+        'Кастомный домен',
+        'Аналитика',
+        'Приоритетная поддержка',
+      ],
+      popular: true,
+    },
+    {
+      id: 'business',
+      name: 'Business',
+      price: '1499₽',
+      features: [
+        'Безлимит страниц',
+        'Командный доступ',
+        'API доступ',
+        'Персональный менеджер',
+      ],
+    },
+  ];
+  const billing = {
+    tariff: tariffs[0],
+    paymentMethod: 'Карта Visa **** **** **** 1234 (действительна до 12/25)',
+    autoRenew: true,
+  };
+  const history = [
+    {
+      date: '01.08.2024',
+      amount: '499₽',
+      status: 'Оплачено',
+      invoiceId: 'INV-2024-001',
+      invoiceLink: '#',
+    },
+    {
+      date: '01.07.2024',
+      amount: '499₽',
+      status: 'Оплачено',
+      invoiceId: 'INV-2024-002',
+      invoiceLink: '#',
+    },
+    {
+      date: '01.06.2024',
+      amount: '499₽',
+      status: 'Оплачено',
+      invoiceId: 'INV-2024-003',
+      invoiceLink: '#',
+    },
+  ];
+  res.json({ tariffs, billing, history });
+});
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,14 @@
 module.exports = {
   content: [
     "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    "./App.{ts,tsx}",
+    "./index.{ts,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./layouts/**/*.{js,ts,jsx,tsx}",
+    "./hooks/**/*.{js,ts,jsx,tsx}",
+    "./ui/**/*.{js,ts,jsx,tsx}",
+    "./routes/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- use local Tailwind build instead of CDN
- include Tailwind directives in CSS and configure purge paths
- expose `/api/home` and `/api/billing` demo endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c0520334832ebf4bc14f39ca2d58