### PR TITLE
Fix loader import issue

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -2,7 +2,7 @@ import type { RouteObject } from 'react-router-dom';
 import { lazy, Suspense } from 'react';
 import MainLayout from '../layouts/MainLayout';
 import StandardPageLayout from '../layouts/StandardPageLayout';
-import Loader from '../components/Loader';
+import { Loader } from '../components/Loader';
 
 // Lazy load pages
 const HomePage = lazy(() => import('../pages/HomePage'));


### PR DESCRIPTION
## Summary
- fix wrong default import for `Loader`

## Testing
- `npm test` *(fails: Failed Suites 4)*

------
https://chatgpt.com/codex/tasks/task_e_6845728e8354832ebc23dafcf09007d1